### PR TITLE
Format description text on main page

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,38 +9,42 @@
 <body>
     <header>
         <h1>Leonard Scheer</h1>
-        <p>In the heart of Switzerland, where precision and discipline are valued, there exists a man who has dedicated his life to two noble pursuits: losing bets and missing training sessions. This is the story of Leonard Scheer, a 22-year-old roller hockey sensation, full-time university student (on paper), and part-time casino donation enthusiast.
+        <h2>In the heart of Switzerland</h2>
+        <p>In the heart of Switzerland, where precision and discipline are valued, there exists a man who has dedicated his life to two noble pursuits: losing bets and missing training sessions. This is the story of Leonard Scheer, a 22-year-old roller hockey sensation, full-time university student (on paper), and part-time casino donation enthusiast.</p>
 
-The Man, The Myth, The Lost Paycheck
-While most students spend their nights studying, Leonard prefers a more intellectually stimulating challenge: trying to turn 20 CHF into 2000 CHF on online blackjack. Unfortunately, his "double or nothing" strategy has resulted in nothing more often than double. It is rumored that he once pawned his roller skates to place a bet, only to later realize that running on a rink is significantly less effective than rolling.
+        <h2>The Man, The Myth, The Lost Paycheck</h2>
+        <p>While most students spend their nights studying, Leonard prefers a more intellectually stimulating challenge: trying to turn 20 CHF into 2000 CHF on online blackjack. Unfortunately, his "double or nothing" strategy has resulted in nothing more often than double. It is rumored that he once pawned his roller skates to place a bet, only to later realize that running on a rink is significantly less effective than rolling.</p>
 
-When confronted about his financial habits, Leonard proudly defends himself:
-"Gambling isn’t a problem if you win… and technically, if you don’t stop, you haven’t lost yet."
+        <p>When confronted about his financial habits, Leonard proudly defends himself:
+        "Gambling isn’t a problem if you win… and technically, if you don’t stop, you haven’t lost yet."</p>
 
-Brilliant. Future economics professor in the making.
+        <p>Brilliant. Future economics professor in the making.</p>
 
-RSC Uttigen’s Unofficial Mascot
-As a roller hockey player for RSC Uttigen, Leonard brings a unique dynamic to the team. Not in terms of skill or dedication—those are highly debatable—but in his ability to turn post-match celebrations into pre-match warm-ups.
+        <h2>RSC Uttigen’s Unofficial Mascot</h2>
+        <p>As a roller hockey player for RSC Uttigen, Leonard brings a unique dynamic to the team. Not in terms of skill or dedication—those are highly debatable—but in his ability to turn post-match celebrations into pre-match warm-ups.</p>
 
-Coaches say he’s one of the most unpredictable players on the field, but that’s mostly because he rarely shows up to training and forgets half the team’s strategies. Teammates describe his playing style as "creative", meaning he often forgets what sport he’s playing halfway through a game. Some fans still remember the time he tried to perform a poker bluff on the referee after a penalty call.
+        <p>Coaches say he’s one of the most unpredictable players on the field, but that’s mostly because he rarely shows up to training and forgets half the team’s strategies. Teammates describe his playing style as "creative", meaning he often forgets what sport he’s playing halfway through a game. Some fans still remember the time he tried to perform a poker bluff on the referee after a penalty call.</p>
 
-A Scholar of Life (and Losing Streaks)
-Despite his university enrollment, Leonard’s real education happens at the local bar. He claims to be "studying human psychology," which mostly involves trying to convince bartenders to let him open a tab. His final thesis might be titled:
-"The Effects of Tequila on Performance: A Case Study on Why I Can’t Remember Last Saturday."
+        <h2>A Scholar of Life (and Losing Streaks)</h2>
+        <p>Despite his university enrollment, Leonard’s real education happens at the local bar. He claims to be "studying human psychology," which mostly involves trying to convince bartenders to let him open a tab. His final thesis might be titled:
+        "The Effects of Tequila on Performance: A Case Study on Why I Can’t Remember Last Saturday."</p>
 
-His professors have grown used to his unique attendance schedule, which follows a strict pattern:
+        <p>His professors have grown used to his unique attendance schedule, which follows a strict pattern:</p>
 
-Monday: Hangover recovery
-Tuesday: Slightly less hungover recovery
-Wednesday: "Might as well start the weekend early"
-Thursday: High-stakes poker night
-Friday: Realization that deadlines exist
-Saturday: Roller hockey game (if awake)
-Sunday: Church (just kidding, more drinking)
-The Future is Bright (Unless It’s the Bar’s Neon Lights)
-Despite his self-destructive tendencies, Leonard remains an icon—a man of mystery, a scholar of luck, and an athlete of questionable endurance. Will he ever quit gambling, stop drinking, and focus on hockey? Probably not. But one thing is certain: whether it’s on the rink or at the roulette table, Leonard Scheer will always bet on himself.
+        <ul>
+            <li>Monday: Hangover recovery</li>
+            <li>Tuesday: Slightly less hungover recovery</li>
+            <li>Wednesday: "Might as well start the weekend early"</li>
+            <li>Thursday: High-stakes poker night</li>
+            <li>Friday: Realization that deadlines exist</li>
+            <li>Saturday: Roller hockey game (if awake)</li>
+            <li>Sunday: Church (just kidding, more drinking)</li>
+        </ul>
 
-And unfortunately, so will his bookie.</p>
+        <h2>The Future is Bright (Unless It’s the Bar’s Neon Lights)</h2>
+        <p>Despite his self-destructive tendencies, Leonard remains an icon—a man of mystery, a scholar of luck, and an athlete of questionable endurance. Will he ever quit gambling, stop drinking, and focus on hockey? Probably not. But one thing is certain: whether it’s on the rink or at the roulette table, Leonard Scheer will always bet on himself.</p>
+
+        <p>And unfortunately, so will his bookie.</p>
     </header>
     <nav>
         <ul>

--- a/styles.css
+++ b/styles.css
@@ -72,3 +72,24 @@ nav ul li a {
 nav ul li a:hover {
     text-decoration: underline;
 }
+
+/* Styles for h2 and h3 tags */
+h2 {
+    font-size: 24px;
+    color: #333;
+    margin-top: 20px;
+}
+
+h3 {
+    font-size: 20px;
+    color: #666;
+    margin-top: 15px;
+}
+
+/* Styles for p tags */
+p {
+    font-size: 16px;
+    color: #333;
+    line-height: 1.5;
+    margin-bottom: 15px;
+}


### PR DESCRIPTION
Format the text describing Leonard Scheer on the main page of the website.

* **index.html**
  - Add `<h2>` and `<h3>` tags to structure the text.
  - Add `<p>` tags to separate paragraphs.
  - Remove the single block of text within the `<p>` tag.
  - Add an unordered list for the attendance schedule.

* **styles.css**
  - Add styles for `<h2>` and `<h3>` tags.
  - Add styles for `<p>` tags.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/griboloski/my-website/pull/3?shareId=d80b07da-ab0f-4050-9826-1bdf4e5d8a2f).