### PR TITLE
Fix text color and contrast issues

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,7 +1,7 @@
 /* Styles for header, main content area, and footer */
 body {
-    background-color: #f4f4f4;
-    color: #333;
+    background-color: #121212;
+    color: white !important;
     padding: 20px;
     font-family: 'Roboto', sans-serif;
 }
@@ -64,7 +64,7 @@ h3 {
 /* Styles for p tags */
 p {
     font-size: 16px;
-    color: #333;
+    color: white !important;
     line-height: 1.6;
     margin-bottom: 15px;
 }
@@ -141,11 +141,30 @@ h3 {
 
 p {
     font-size: 16px;
-    color: #333;
+    color: white !important;
     line-height: 1.6;
     margin-bottom: 15px;
 }
 
 .hidden {
     display: none;
+}
+
+body, p, span, div {
+    color: white !important;
+}
+
+pre, code {
+    color: #ffffff;
+    background-color: #222;
+}
+
+* {
+    opacity: 1 !important;
+    visibility: visible !important;
+}
+
+* {
+    text-shadow: none !important;
+    filter: none !important;
 }


### PR DESCRIPTION
Update `styles.css` to improve text color contrast and reset certain CSS properties.

* Change `body` background color to `#121212` and text color to white.
* Set text color to white for `p, span, div` elements.
* Add CSS rules for `pre` and `code` elements to set text color to `#ffffff` and background color to `#222`.
* Add CSS rules to reset `opacity` and `visibility` properties for all elements.
* Add CSS rules to reset `text-shadow` and `filter` effects for all elements.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/griboloski/my-website/pull/12?shareId=70a30309-90c0-4de7-adda-c60760790b43).